### PR TITLE
Remove conda dependency for sh installation

### DIFF
--- a/constructor/sh/construct.yaml
+++ b/constructor/sh/construct.yaml
@@ -24,5 +24,3 @@ specs:
   - python >=3.7
   - ibis-framework
   - jupyterlab >=2.2
-  # needed for pkg building
-  - conda


### PR DESCRIPTION
Follow-up of #12 
Remove conda dependency for sh installation