### PR TITLE
Fix post install

### DIFF
--- a/constructor/post-install.sh
+++ b/constructor/post-install.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-$PREFIX/bin/python -m pip install ibis-vega-transform
+export OLD_PATH=$PREFIX
+export PATH=$PREFIX/bin:$PATH
 
-$PREFIX/bin/jupyter labextension install ibis-vega-transform
-$PREFIX/bin/jupyter labextension install @pyviz/jupyterlab_pyviz
+python -m pip install ibis-vega-transform
+
+jupyter labextension install ibis-vega-transform
+jupyter labextension install @pyviz/jupyterlab_pyviz
+
+export PATH=$OLD_PATH


### PR DESCRIPTION
As post-install call jupyter command, it under the hood calls node, so it should be available in the environment.

```sh
File "/Users/xmn/omnisci/lib/python3.7/site-packages/jupyterlab/commands.py", line 1758, in _node_check
    node = which('node')
```