### PR TITLE
Pin ibis to a minimum patch number (dev)

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -69,6 +69,7 @@ jobs:
         /Users/runner/omnisci/bin/python -c "import holoviews"
         /Users/runner/omnisci/bin/python -c "import graphviz"
         /Users/runner/omnisci/bin/python -c "import pydot"
+        /Users/runner/omnisci/bin/python -c "from ibis.expr.operations import RowID"
 
     - name: create release
       id: create_release

--- a/constructor/pkg/construct.yaml
+++ b/constructor/pkg/construct.yaml
@@ -28,7 +28,7 @@ specs:
   - python >=3.7
   - jupyterlab >=2.2
   # local depencencies
-  - ibis-framework 1.3.0
+  - ibis-framework >=1.3.1
   - holoviews 1.13.4
   - hvplot 0.6.0
   # needed for pkg building

--- a/constructor/sh/construct.yaml
+++ b/constructor/sh/construct.yaml
@@ -28,7 +28,7 @@ specs:
   - python >=3.7
   - jupyterlab >=2.2
   # local depencencies
-  - ibis-framework 1.3.0
+  - ibis-framework >=1.3.1
   - holoviews 1.13.4
   - hvplot 0.6.0
 


### PR DESCRIPTION
This PR pins ibis-framework to 1.3.1, this version is available only on quansight/label/omnisci channel. So it would be forced to be used. Also added a test to check if the ibis used has `rowid` operation (minimum requirement).