### PR TITLE
Test omnisci examples on ci

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -28,7 +28,7 @@ jobs:
         sudo sysctl -w kern.maxfiles=204800
         sudo sysctl -w kern.maxfilesperproc=245670
 
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
@@ -41,13 +41,13 @@ jobs:
         conda install -y constructor conda-build
         wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-osx-64.exe -O conda.exe
 
-    - name: run constructor for pkg
-      id: pkg_name
-      shell: bash -l {0}
-      run: |
-        constructor --conda-exe conda.exe constructor/pkg
-        PKG_NAME=$(ls omnisci-*-MacOSX-x86_64.pkg)
-        echo "::set-output name=filename::$PKG_NAME"
+    # - name: run constructor for pkg
+    #   id: pkg_name
+    #   shell: bash -l {0}
+    #   run: |
+    #     constructor --conda-exe conda.exe constructor/pkg
+    #     PKG_NAME=$(ls omnisci-*-MacOSX-x86_64.pkg)
+    #     echo "::set-output name=filename::$PKG_NAME"
 
     - name: run constructor for sh
       id: sh_name
@@ -60,16 +60,22 @@ jobs:
     - name: test shell package
       run: |
         bash ${{ steps.sh_name.outputs.filename }} -b
-        /Users/runner/omnisci/bin/python -c "import ibis.omniscidb"
-        /Users/runner/omnisci/bin/python -c "import pymapd"
-        /Users/runner/omnisci/bin/python -c "import intake"
-        /Users/runner/omnisci/bin/python -c "import altair"
-        /Users/runner/omnisci/bin/python -c "import ibis_vega_transform"
-        /Users/runner/omnisci/bin/python -c "import geoviews"
-        /Users/runner/omnisci/bin/python -c "import holoviews"
-        /Users/runner/omnisci/bin/python -c "import graphviz"
-        /Users/runner/omnisci/bin/python -c "import pydot"
-        /Users/runner/omnisci/bin/python -c "from ibis.expr.operations import RowID"
+        source conda_activate.sh
+        python -c "import ibis.omniscidb"
+        python -c "import pymapd"
+        python -c "import intake"
+        python -c "import altair"
+        python -c "import ibis_vega_transform"
+        python -c "import geoviews"
+        python -c "import holoviews"
+        python -c "import graphviz"
+        python -c "import pydot"
+        python -c "from ibis.expr.operations import RowID"
+        # install nbconvert for the tests
+        conda install -y nbconvert
+        # run notebook tests
+        bash test_notebooks.sh
+
 
     - name: create release
       id: create_release
@@ -83,7 +89,8 @@ jobs:
         tag: ${{ github.event.release.tag_name }}
         name: Release ${{ github.event.release.tag_name }}
         commit: master
-        artifacts: ${{ steps.pkg_name.outputs.filename }},${{ steps.sh_name.outputs.filename }}
+        # artifacts: ${{ steps.pkg_name.outputs.filename }},${{ steps.sh_name.outputs.filename }}
+        artifacts: ${{ steps.sh_name.outputs.filename }}
         artifactContentType: application/octet-stream
         body: Release ${{ github.event.release.tag_name }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 # deployment
 rever/*
 
+# temporary folders for tests
+omnisci-examples
+tmp

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo sysctl -w kern.maxfilesperproc=245670
 Now you may run constructor with the following command:
 
 ```sh
-constructor --conda-exe /path/to/conda.exe constructor/
+constructor --conda-exe /path/to/conda.exe constructor/sh
 ```
 
 Be aware that, on Mac, whether you are creating a sh-based or pkg-based installer
@@ -60,12 +60,13 @@ the `installer_type` key to have a value of `pkg` or `sh` depending on what you 
 
 ## Gotchas
 
-The pkg installer seems to need to have `conda` itself listed as a spec right now.
+The `pkg` and `sh` installer seem to need to have `conda` itself listed as a spec.
+Without that when it tries to run `conda init` it will fail.
 
 
 ## Releasing
 
-For releasing, after the PR is merged, create a tag with the last commit from master and 
+For releasing, after the PR is merged, create a tag with the last commit from master and
 push it to the repository, for example:
 
 ```sh
@@ -85,19 +86,17 @@ OmniSci Data Science package installs OmniSci stack that includes intake/intake-
 
 Follow the instructions below for your current setup:
 
-**If you have no conda installed on your machine**  
+**If you have no conda installed on your machine**
 IMPORTANT: If you already have conda installed, this will overwrite the conda path in your bash profile! If you really want to run the following instructions, you probably want to create first a backup of your configuration files (for example, `$HOME/.bashrc`, `$HOME/.bash_profile`, `$HOME/.zshrc`, according to your environment). Otherwise, check the instructions in the sections below.
 
-The OmniSci Data Science Installer can be installed using a shell script if you have no conda on your machine. The shell installers for each version of the package are available on the GitHub  [releases page](https://github.com/Quansight/omnisci-datascience-installer/releases/). For each release, you will find both a MacOS package (`pkg`) and a shell (`sh`) installer. 
+The OmniSci Data Science Installer can be installed using a shell script if you have no conda on your machine. The shell installers for each version of the package are available on the GitHub  [releases page](https://github.com/Quansight/omnisci-datascience-installer/releases/). For each release, you will find a shell (`sh`) installer.
 
-
-NOTE: The MacOS package (`pkg`) installer is still being tested.
 
 To run the shell installer:
 
 First, download the shell package (`omnisci-<release_ver>-MacOSX-x86_64.sh`) `omnisci-datascience-installer` [release page](https://github.com/Quansight/omnisci-datascience-installer/releases/) and add execution permission to it:
 
-Download the installer and ensure that you have execution permission for the package. 
+Download the installer and ensure that you have execution permission for the package.
 ```sh
 wget https://github.com/Quansight/omnisci-datascience-installer/releases/download/0.0.2/omnisci-0.0.2-MacOSX-x86_64.sh
 chmod +x omnisci-0.0.2-MacOSX-x86_64.sh
@@ -116,22 +115,22 @@ Otherwise, you can execute the shell script with no flags:
 
 You can scroll through the license agreement by hitting enter or spacebar. If you'd like to skip to the end, you can select `q`
 
-Once you have agreed the the license agreement and the install location, the installer will unpack all the required packages into the the install location. 
+Once you have agreed the the license agreement and the install location, the installer will unpack all the required packages into the the install location.
 
-You will see that your `bash` profile has been modified to include the conda path. In order to utilize conda, you'll need to either close and reopen your terminal, or you can source this updated file.  
+You will see that your `bash` profile has been modified to include the conda path. In order to utilize conda, you'll need to either close and reopen your terminal, or you can source this updated file.
 
 ```sh
 source .bash_profile
 ```
 
-You have successfully installed the OmniSci Datascience Installer on your Mac in the `base` conda environment. This environment has already been activated for you. You are now ready to run some examples! 
+You have successfully installed the OmniSci Datascience Installer on your Mac in the `base` conda environment. This environment has already been activated for you. You are now ready to run some examples!
 
 
 **If you already have conda installed:**
 
-If you already have Conda installed on your Mac, you can create the OmniSci environment directly. These instructions provide the zip example, but you could also use git commands to download the repository. 
+If you already have Conda installed on your Mac, you can create the OmniSci environment directly. These instructions provide the zip example, but you could also use git commands to download the repository.
 
-Download the repository. A separate zip file is available for each version (e.g. we're downloading v0.1.0 here). 
+Download the repository. A separate zip file is available for each version (e.g. we're downloading v0.1.0 here).
 
 ```sh
 wget https://github.com/Quansight/omnisci-examples/archive/v0.1.0.zip
@@ -142,7 +141,7 @@ unzip v0.1.0.zip
 cd omnisci-examples-0.1.0
 ```
 
-Create a new conda environment. This will download all the necessary packages. 
+Create a new conda environment. This will download all the necessary packages.
 ```sh
 conda env create -f environment.yml -n omnisci
 ```
@@ -150,7 +149,7 @@ Activate the new enviroment (requires you to have run `conda init`)
 ```sh
 conda activate omnisci
 ```
-You have successfully installed the OmniSci Datascience Installer on your Mac in the `omnisci` conda environment. You are now ready to run some examples! 
+You have successfully installed the OmniSci Datascience Installer on your Mac in the `omnisci` conda environment. You are now ready to run some examples!
 
 
 
@@ -192,9 +191,9 @@ import ibis
 client = ibis.omniscidb.connect(
     host="localhost",
     port="16274",
-    database="omnisci", 
+    database="omnisci",
     user="admin",
-    password="HyperInteractive", 
+    password="HyperInteractive",
 )
 # get the name of all tables available
 client.list_tables()

--- a/conda_activate.sh
+++ b/conda_activate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ex
+ENV_PATH=${HOME}/omnisci
+CONDA_PATH=${ENV_PATH}/bin/conda
+# >>> conda initialize >>>
+# !! Contents within this block are managed by 'conda init' !!
+__conda_setup="$(${CONDA_PATH} 'shell.bash' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "${ENV_PATH}/etc/profile.d/conda.sh" ]; then
+        . "${ENV_PATH}/etc/profile.d/conda.sh"
+    else
+        export PATH="${ENV_PATH}/bin:$PATH"
+    fi
+fi
+unset __conda_setup
+# <<< conda initialize <<<
+set +ex

--- a/constructor/environment.yaml
+++ b/constructor/environment.yaml
@@ -1,0 +1,29 @@
+channels:
+  - quansight/label/omnisci
+  - conda-forge
+dependencies:
+  - altair
+  - bokeh
+  - conda
+  - geoviews
+  - quansight/label/omnisci::hvplot
+  - quansight/label/omnisci::holoviews
+  - ibis-framework >=1.4
+  - intake >=0.5.3
+  - jaeger
+  - jupyterlab >=2.2
+  - jupyter-jaeger
+  - nodejs >=12
+  - notebook
+  - omnisci-pytools
+  - pandas
+  - pip
+  # pyarrow 0.15.1 is raising an error: Library not loaded: @rpath/libprotobuf.22.dylib
+  - pyarrow 0.15.0
+  - pydot
+  - pymapd >=0.24
+  - python 3.7.*
+  - rbc >=0.4
+  - pip:
+    - intake-omnisci
+    - ibis-vega-transform

--- a/constructor/environment.yaml
+++ b/constructor/environment.yaml
@@ -25,5 +25,7 @@ dependencies:
   - python 3.7.*
   - rbc >=0.4
   - pip:
+    # as it is not recognized by conda constructor
+    # it should installed by post-install.sh
     - intake-omnisci
     - ibis-vega-transform

--- a/constructor/environment.yaml
+++ b/constructor/environment.yaml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - altair
+  - arrow-cpp 0.15.0
   - bokeh
   - conda
   - geoviews

--- a/constructor/pkg/construct.yaml
+++ b/constructor/pkg/construct.yaml
@@ -15,23 +15,6 @@ channels:
 
 license_file: ../license.txt
 
-specs:
-  - intake >=0.5.3
-  - intake-omnisci
-  - geoviews
-  - omnisci-pytools
-  - jupyter-jaeger
-  - pandas <0.26
-  - pydot
-  - pymapd
-  - pyarrow 0.15
-  - python >=3.7
-  - jupyterlab >=2.2
-  # local depencencies
-  - ibis-framework >=1.3.1
-  - holoviews 1.13.4
-  - hvplot 0.6.0
-  # needed for pkg building
-  - conda
+environment_file: ../environment.yaml
 
 post_install: ../post-install.sh  # [osx]

--- a/constructor/post-install.sh
+++ b/constructor/post-install.sh
@@ -3,6 +3,9 @@
 export OLD_PATH=$PREFIX
 export PATH=$PREFIX/bin:$PATH
 
+pip install intake-omnisci
+pip install ibis-vega-transform
+
 jupyter labextension install ibis-vega-transform
 jupyter labextension install @pyviz/jupyterlab_pyviz
 

--- a/constructor/post-install.sh
+++ b/constructor/post-install.sh
@@ -3,8 +3,6 @@
 export OLD_PATH=$PREFIX
 export PATH=$PREFIX/bin:$PATH
 
-python -m pip install ibis-vega-transform
-
 jupyter labextension install ibis-vega-transform
 jupyter labextension install @pyviz/jupyterlab_pyviz
 

--- a/constructor/sh/construct.yaml
+++ b/constructor/sh/construct.yaml
@@ -6,7 +6,7 @@ keep_pkgs: True
 attempt_hardlinks: True
 ignore_duplicate_files: True
 install_in_dependency_order: True
-installer_type: sh  # [osx]
+installer_type: sh
 
 channels:
   - https://conda.anaconda.org/quansight/label/omnisci
@@ -15,21 +15,6 @@ channels:
 
 license_file: ../license.txt
 
-specs:
-  - intake >=0.5.3
-  - intake-omnisci
-  - geoviews
-  - omnisci-pytools
-  - jupyter-jaeger
-  - pandas <0.26
-  - pydot
-  - pymapd
-  - pyarrow 0.15
-  - python >=3.7
-  - jupyterlab >=2.2
-  # local depencencies
-  - ibis-framework >=1.3.1
-  - holoviews 1.13.4
-  - hvplot 0.6.0
+environment_file: ../environment.yaml
 
-post_install: ../post-install.sh  # [osx]
+post_install: ../post-install.sh

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,3 +4,4 @@ dependencies:
   - python
   - rever
   - constructor
+  - pip

--- a/test_notebooks.sh
+++ b/test_notebooks.sh
@@ -15,17 +15,17 @@ mkdir -p tmp
 
 find ${OMNISCI_EXAMPLE_DIR} -type f \( -iname "*.ipynb" ! -iname "*checkpoint.ipynb" \) | while read f
 do
+    # skip in the following cases:
+    # - when notebook runs a local docker compose and it is not necessary for the tests
+    # - when notebook connects to omnisci using localhost address
+    # - when notebook uses demo_vote_clean table: 'utf-8' codec can't decode byte
     if \
-        # this notebook run a local docker compose and it is not necessary for the tests
         [ "$f" == "${NOTEBOOK_DIR}/01_Introduction.ipynb" ] || \
-        # these notebooks connect to omnisci using localhost address
         [ "$f" == "${NOTEBOOK_DIR}/additional_examples/A01_Getting_Started_OmniSciDB_and_Ibis.ipynb" ] || \
         [ "$f" == "${NOTEBOOK_DIR}/additional_examples/A02_Omnisci_Runtime_UDF.ipynb" ] || \
         [ "$f" == "${NOTEBOOK_DIR}/02_Querying_Data.ipynb" ] || \
         [ "$f" == "${NOTEBOOK_DIR}/04_Advanced-Using_UDFs_and_UDTFs.ipynb" ] || \
-        [ "$f" == "${NOTEBOOK_DIR}/workshop/User_Defined_Algorithms_on_Big_Data.ipynb" ] \
-        # pymapd has problems to deal with some data from demo_vote_clean table
-        # 'utf-8' codec can't decode byte
+        [ "$f" == "${NOTEBOOK_DIR}/workshop/User_Defined_Algorithms_on_Big_Data.ipynb" ] || \
         [ "$f" == "${NOTEBOOK_DIR}/workshop/Altair_Ibis_Vega_for_Interactive_Exploration.ipynb" ] || \
         [ "$f" == "${NOTEBOOK_DIR}/workshop/Connecting_Holoviz_Visualization_Ecosystem_to_OmniSci_part_1.ipynb" ] \
     ; then

--- a/test_notebooks.sh
+++ b/test_notebooks.sh
@@ -24,6 +24,10 @@ do
         [ "$f" == "${NOTEBOOK_DIR}/02_Querying_Data.ipynb" ] || \
         [ "$f" == "${NOTEBOOK_DIR}/04_Advanced-Using_UDFs_and_UDTFs.ipynb" ] || \
         [ "$f" == "${NOTEBOOK_DIR}/workshop/User_Defined_Algorithms_on_Big_Data.ipynb" ] \
+        # pymapd has problems to deal with some data from demo_vote_clean table
+        # 'utf-8' codec can't decode byte
+        [ "$f" == "${NOTEBOOK_DIR}/workshop/Altair_Ibis_Vega_for_Interactive_Exploration.ipynb" ] || \
+        [ "$f" == "${NOTEBOOK_DIR}/workshop/Connecting_Holoviz_Visualization_Ecosystem_to_OmniSci_part_1.ipynb" ] \
     ; then
         echo "[II] Skipping ${f}"
         continue;

--- a/test_notebooks.sh
+++ b/test_notebooks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -ex
+
+PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+OMNISCI_EXAMPLE_DIR=${PROJECT_DIR}/omnisci-examples
+NOTEBOOK_DIR=${OMNISCI_EXAMPLE_DIR}/notebooks
+NBCONVERT=${CONDA_PREFIX}/bin/jupyter-nbconvert
+OUTPUT_DIR=${PROJECT_DIR}/tmp
+
+# force a fresh copy of the omnisci-examples repository
+rm -rf ${OMNISCI_EXAMPLE_DIR}
+git clone --depth 1 https://github.com/Quansight/omnisci-examples.git
+
+mkdir -p tmp
+
+find ${OMNISCI_EXAMPLE_DIR} -type f \( -iname "*.ipynb" ! -iname "*checkpoint.ipynb" \) | while read f
+do
+    if \
+        # this notebook run a local docker compose and it is not necessary for the tests
+        [ "$f" == "${NOTEBOOK_DIR}/01_Introduction.ipynb" ] || \
+        # these notebooks connect to omnisci using localhost address
+        [ "$f" == "${NOTEBOOK_DIR}/additional_examples/A01_Getting_Started_OmniSciDB_and_Ibis.ipynb" ] || \
+        [ "$f" == "${NOTEBOOK_DIR}/additional_examples/A02_Omnisci_Runtime_UDF.ipynb" ] || \
+        [ "$f" == "${NOTEBOOK_DIR}/02_Querying_Data.ipynb" ] || \
+        [ "$f" == "${NOTEBOOK_DIR}/04_Advanced-Using_UDFs_and_UDTFs.ipynb" ] || \
+        [ "$f" == "${NOTEBOOK_DIR}/workshop/User_Defined_Algorithms_on_Big_Data.ipynb" ] \
+    ; then
+        echo "[II] Skipping ${f}"
+        continue;
+    fi
+
+    ${NBCONVERT} --to notebook --execute --output ${OUTPUT_DIR}/test.html ${f}
+    if [ $? -ne 0 ]
+    then
+        break
+    fi
+done
+
+set +ex


### PR DESCRIPTION
This PR:

- updates ibis dependencies
- using the new conda constructor 3.2, now constructor.yaml can define dependencies from an environment.yml using `environment_file` key.
- fixes the issue during the installation when try to run conda init (because conda was not defined as dependency for sh package)
- updates setup-miniconda on ci (`conda-incubator/setup-miniconda@v2`)
- skips packaging for pkg
- tests notebooks from omnisci-examples
