### PR TITLE
Pin numpy<1.20

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -29,6 +29,9 @@ requirements:
     - jupyter-jaeger >=1.0.4
     - nodejs >=12
     - notebook
+    # NOTE: numpy pinned to fix the following error:
+    #   AttributeError: type object 'object' has no attribute 'dtype'
+    - numpy <1.20
     - omnisci-pytools
     - pandas
     - pip

--- a/constructor/environment.yaml
+++ b/constructor/environment.yaml
@@ -19,6 +19,9 @@ dependencies:
   - jupyter-jaeger >=1.0.4
   - nodejs >=12
   - notebook
+  # NOTE: numpy pinned to fix the following error:
+  #   AttributeError: type object 'object' has no attribute 'dtype'
+  - numpy <1.20
   - omnisci-pytools
   - pandas
   - pip


### PR DESCRIPTION
This PR pins numpy <1.20 to fix the following error:
`AttributeError: type object 'object' has no attribute 'dtype'`